### PR TITLE
Improvements may 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,13 @@
 
 * initial release.
 
-
 ## 1.0.0
 
 * improved documentation.
 
-
 ## 1.0.1
 
 * downgrade min Dart Sdk.
-
 
 ## 1.0.2
 
@@ -35,3 +32,11 @@
 
 * Consistent Platform error handling.
 * Upgrade dependencies.
+
+## 2.1.0
+
+* Returns "biometric" for Android devices with multiple BIOMETRIC_STRONG options when called
+  biometricAuthAvailable().
+* Let createSignature() accept a "payload" keyValue pair in options arg.
+* updates dependencies.
+* updates README.md and the Example.

--- a/README.md
+++ b/README.md
@@ -106,16 +106,20 @@ class BiometricAuthButton extends StatelessWidget {
     return ElevatedButton(
       child: Text('Authenticate with Biometrics'),
       onPressed: () async {
-        if (await _biometricSignature.canCheckBiometrics) {
-          final biometrics = await _biometricSignature.getAvailableBiometrics();
-          if (biometrics.isNotEmpty) {
-            try {
-              final String? signature = await _biometricSignature.createSignature(
-                  options: {"promptMessage": "You are Welcome!"});
-            } on PlatformException catch (e) {
-              debugPrint(e.message);
-              debugPrint(e.code);
-            }
+        final biometrics = await _biometricSignature
+            .biometricAuthAvailable();
+        if (!biometrics!.contains("none, ")) {
+          try {
+            final String? publicKey = await _biometricSignature
+                .createKeys();
+            final String? signature = await _biometricSignature
+                .createSignature(
+                options: {
+                  "payload": "Payload to sign",
+                  "promptMessage": "You are Welcome!"});
+          } on PlatformException catch (e) {
+            debugPrint(e.message);
+            debugPrint(e.code);
           }
         }
       },

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started with Biometric Signature, follow these steps:
 
 ```yaml
 dependencies:
-  biometric_signature: ^2.0.0
+  biometric_signature: ^2.1.0
 ```
 
 |             | Android | iOS   |

--- a/android/src/main/kotlin/com/chamoda/nethra/biometric_signature/BiometricSignaturePlugin.kt
+++ b/android/src/main/kotlin/com/chamoda/nethra/biometric_signature/BiometricSignaturePlugin.kt
@@ -180,7 +180,7 @@ class BiometricSignaturePlugin : FlutterPlugin, MethodCallHandler, ActivityAware
       val androidBiometrics = listOf("fingerprint", "face", "iris")
       val biometricsList = androidBiometrics.filter { rawString.contains(it, ignoreCase = true) }
 
-      return if (biometricsList.size == 1) biometricsList[0] else "biometrics"
+      return if (biometricsList.size == 1) biometricsList[0] else "biometric"
     }
 
     val biometricManager = BiometricManager.from(activity)

--- a/android/src/main/kotlin/com/chamoda/nethra/biometric_signature/BiometricSignaturePlugin.kt
+++ b/android/src/main/kotlin/com/chamoda/nethra/biometric_signature/BiometricSignaturePlugin.kt
@@ -109,7 +109,8 @@ class BiometricSignaturePlugin : FlutterPlugin, MethodCallHandler, ActivityAware
     try {
       val cancelButtonText = options?.get("cancelButtonText") ?: "Cancel"
       val promptMessage = options?.get("promptMessage") ?: "Welcome"
-      val payload = Base64.encodeToString("arhten adomahc".toByteArray(Charsets.UTF_8), Base64.DEFAULT)
+      val rawPayload =  options?.get("payload") ?: "arhten adomahc"
+      val payload = Base64.encodeToString(rawPayload.toByteArray(Charsets.UTF_8), Base64.DEFAULT)
       val signature = Signature.getInstance("SHA256withRSA")
       val keyStore = KeyStore.getInstance("AndroidKeyStore")
       keyStore.load(null)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - biometric_signature (0.0.1):
+  - biometric_signature (2.0.0):
     - Flutter
   - Flutter (1.0.0)
 
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  biometric_signature: 88aca07ab2e14d267b608aad14955b2f2ec625a0
+  biometric_signature: 06b9615f1d192f08cfe7db5aa016beccb6217c12
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.15.2

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,7 +30,7 @@ class _MyAppState extends State<MyApp> {
           await _biometricSignature.biometricAuthAvailable();
       debugPrint("biometricsType : $biometricsType");
       // if (condition) {
-      //   final bool? result = await _biometricSignaturePlugin.deleteKeys();
+      //   final bool? result = await _biometricSignature.deleteKeys();
       // }
       final bool doExist =
           await _biometricSignature.biometricKeyExists() ?? false;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final _biometricSignaturePlugin = BiometricSignature();
+  final _biometricSignature = BiometricSignature();
 
   @override
   void initState() {
@@ -27,20 +27,23 @@ class _MyAppState extends State<MyApp> {
   Future<void> asyncInit() async {
     try {
       final String? biometricsType =
-          await _biometricSignaturePlugin.biometricAuthAvailable();
+          await _biometricSignature.biometricAuthAvailable();
       debugPrint("biometricsType : $biometricsType");
       // if (condition) {
       //   final bool? result = await _biometricSignaturePlugin.deleteKeys();
       // }
       final bool doExist =
-          await _biometricSignaturePlugin.biometricKeyExists() ?? false;
+          await _biometricSignature.biometricKeyExists() ?? false;
       debugPrint("doExist : $doExist");
       if (!doExist) {
-        final String? publicKey = await _biometricSignaturePlugin.createKeys();
+        final String? publicKey = await _biometricSignature.createKeys();
         debugPrint("publicKey : $publicKey");
       }
-      final String? signature = await _biometricSignaturePlugin
-          .createSignature(options: {"promptMessage": "You are Welcome!"});
+      final String? signature = await _biometricSignature.createSignature(
+          options: {
+            "payload": "Biometric payload",
+            "promptMessage": "You are Welcome!"
+          });
       debugPrint("signature : $signature");
     } on PlatformException catch (e) {
       debugPrint(e.message);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/Classes/BiometricSignaturePlugin.swift
+++ b/ios/Classes/BiometricSignaturePlugin.swift
@@ -130,7 +130,7 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
     
     private func createSignature(options: Dictionary<String, String>?, result: @escaping FlutterResult) {
         let promptMessage = options?["promptMessage"] ?? "Welcome"
-        let payload = "arhten adomahc"
+        let payload = options?["payload"] ?? "arhten adomahc"
         let tag = getBiometricKeyTag()
         let query: [AnyHashable: Any] = [
             kSecClass: kSecClassKey,

--- a/ios/biometric_signature.podspec
+++ b/ios/biometric_signature.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'biometric_signature'
-  s.version          = '2.0.0'
+  s.version          = '2.1.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/biometric_signature.dart
+++ b/lib/biometric_signature.dart
@@ -12,7 +12,7 @@ class BiometricSignature {
 
   /// Creates a digital signature using biometric authentication
   ///
-  /// params: A map of options, {"promptMessage": "// your welcome message", "cancelButtonText": "Cancel"(on Android only)}
+  /// params: A map of options, {"payload": "// your payload", "promptMessage": "// your welcome message", "cancelButtonText": "Cancel"(on Android only)}
   /// - Returns: Either the created signature as a base64 encoded string or an error
   Future<String?> createSignature({Map<String, String>? options}) async {
     final String? response = await BiometricSignaturePlatform.instance

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: biometric_signature
 description: Flutter biometric functionality for cryptographic signing and encryption
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/chamodanethra/biometric_signature
 
 environment:


### PR DESCRIPTION
- Fixed https://github.com/chamodanethra/biometric_signature/issues/5
- Returns "biometric" for Android devices with multiple BIOMETRIC_STRONG options when called
  biometricAuthAvailable().
- Let createSignature() accept a "payload" keyValue pair in options arg.