### PR TITLE
Fix ios biometric auth bypass bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.3] - 2024-07-27
+
+* fix Local Authentication bypass in iOS when calling createSignature().
+
 ## [4.0.2] - 2024-07-22
 
 * fix Biometric portal not coming up in iOS simulators when calling createSignature().

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started with Biometric Signature, follow these steps:
 
 ```yaml
 dependencies:
-  biometric_signature: ^4.0.2
+  biometric_signature: ^4.0.3
 ```
 
 |             | Android | iOS   |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - biometric_signature (4.0.2):
+  - biometric_signature (4.0.3):
     - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  biometric_signature: c49a051b8c7b034b634b6430cabd010f9379962a
+  biometric_signature: 5b8259d9feeba9597becd2c3652d9e2b587ce311
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 13825b8a9334a850581300559b8839134b124670
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.2"
+    version: "4.0.3"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/Classes/BiometricSignaturePlugin.swift
+++ b/ios/Classes/BiometricSignaturePlugin.swift
@@ -209,8 +209,6 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
                 }
             } else {
                 let errorCode = (error as? LAError)?.code == .userCancel ? Constants.userCanceled : Constants.authFailed
-                // TODO: remove below line
-                print((error as? LAError)?.code.rawValue)
                 self.dispatchMainAsync {
                     result(FlutterError(code: errorCode, message: error?.localizedDescription ?? "Authentication failed", details: nil))
                 }

--- a/ios/biometric_signature.podspec
+++ b/ios/biometric_signature.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'biometric_signature'
-  s.version          = '4.0.2'
+  s.version          = '4.0.3'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: biometric_signature
 description: Flutter biometric functionality for cryptographic signing and encryption
-version: 4.0.2
+version: 4.0.3
 homepage: https://github.com/chamodanethra/biometric_signature
 
 environment:


### PR DESCRIPTION
- LAContext().evaluatePolicy() method call was removed from createSignature() and reimplemented its logic with evaluateAccessControl().
- Suggested fix for https://github.com/chamodanethra/biometric_signature/issues/10