### PR TITLE
Update version to 4.2.0 and fix iOS biometric key validity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.2.0] - 2024-09-14
+
+* Fix [iOs issue: biometricKeyExists always false ](https://github.com/chamodanethra/biometric_signature/issues/12).
+
 ## [4.1.1] - 2024-08-26
 
 * Fix linting issues.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started with Biometric Signature, follow these steps:
 
 ```yaml
 dependencies:
-  biometric_signature: ^4.1.1
+  biometric_signature: ^4.2.0
 ```
 
 |             | Android | iOS   |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - biometric_signature (4.0.3):
+  - biometric_signature (4.2.0):
     - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  biometric_signature: 5b8259d9feeba9597becd2c3652d9e2b587ce311
+  biometric_signature: e1bfd4125bc2fc615c11172e199ee299cfe3f356
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 13825b8a9334a850581300559b8839134b124670
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,7 +34,7 @@ class _MyAppState extends State<MyApp> {
       //   final bool? result = await _biometricSignature.deleteKeys();
       // }
       final bool doExist =
-          await _biometricSignature.biometricKeyExists() ?? false;
+          await _biometricSignature.biometricKeyExists(checkValidity: true) ?? false;
       debugPrint("doExist : $doExist");
       if (!doExist) {
         final String? publicKey = await _biometricSignature.createKeys(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.1.1"
+    version: "4.2.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/biometric_signature.podspec
+++ b/ios/biometric_signature.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'biometric_signature'
-  s.version          = '4.1.1'
+  s.version          = '4.2.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: biometric_signature
 description: Flutter biometric functionality for cryptographic signing and encryption
-version: 4.1.1
+version: 4.2.0
 homepage: https://github.com/chamodanethra/biometric_signature
 
 environment:


### PR DESCRIPTION
- Fix iOS issue with `biometricKeyExists` always returning false.
- Update plugin version in various files to 4.2.0.
- Modify logic for checking the validity of biometric keys.