### PR TITLE
Feat/create keys enforce biometric

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,15 @@ Generates a new RSA 2048 key pair for biometric authentication. The private key 
 
 - `androidConfig`: An `AndroidConfig` object containing following properties:
   - `useDeviceCredentials`: A bool to indicate whether Device Credentials' fallback support is needed for the compatible Android devices.
+  - `enforceBiometric`: (optional) A bool to indicate if prompt biometric authentication before generating key-pair. If authentication doesn't pass key-pair is not generated. Defaults to false
+  - `options`: A map containing the following keys:
+    - `cancelButtonText` (optional) : Text for the cancel button in the biometric prompt. Default is "Cancel".
+    - `promptMessage` : (optional): Message to display in the biometric prompt. Default is "Authentication".
 - `iosConfig`: An `IosConfig` object containing following properties:
-    - `useDeviceCredentials`: A bool to indicate whether Device Credentials' fallback support is needed.
+  - `useDeviceCredentials`: A bool to indicate whether Device Credentials' fallback support is needed.
+  - `enforceBiometric`: (optional) A bool to indicate if prompt biometric authentication before generating key-pair. If authentication doesn't pass key-pair is not generated. Defaults to false
+    - `options`: A map containing the following keys:
+      - `promptMessage` : (optional): Message to display in the biometric prompt. Default is "Authentication".
 
 - **Returns**: `String` - The base64 encoded public key.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,8 +40,14 @@ class _MyAppState extends State<MyApp> {
       debugPrint("doExist : $doExist");
       if (!doExist) {
         final String? publicKey = await _biometricSignature.createKeys(
-            androidConfig: AndroidConfig(useDeviceCredentials: true),
-            iosConfig: IosConfig(useDeviceCredentials: false));
+            androidConfig: AndroidConfig(
+              useDeviceCredentials: true,
+              enforceBiometric: true,
+            ),
+            iosConfig: IosConfig(
+              useDeviceCredentials: false,
+              enforceBiometric: true,
+            ));
         debugPrint("publicKey : $publicKey");
       }
       final String? signature =

--- a/lib/android_config.dart
+++ b/lib/android_config.dart
@@ -1,7 +1,19 @@
 class AndroidConfig {
   bool useDeviceCredentials;
+  bool enforceBiometric;
+  Map<String?, String?>? options;
 
   AndroidConfig({
     required this.useDeviceCredentials,
+    this.enforceBiometric = false,
+    this.options,
   });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'useDeviceCredentials': useDeviceCredentials,
+      'enforceBiometric': enforceBiometric,
+      'options': options,
+    };
+  }
 }

--- a/lib/biometric_signature.dart
+++ b/lib/biometric_signature.dart
@@ -7,6 +7,8 @@ class BiometricSignature {
   /// Creates a RSA key pair on the device, stores Private Key in keychain/keystore
   ///
   /// params: An optional AndroidConfig object containing the bool useDeviceCredentials, which attempts to use it on compatible devices and an optional IosConfig object containing the bool useDeviceCredentials
+  /// both configs contain bool enforceBiometric which prompts biometric before generating key-pair when true
+  /// config contains also map of options, {"promptMessage": "// your welcome message", "cancelButtonText": "Cancel"(on Android only)}
   /// Returns: The Public Key component as a String
   Future<String?> createKeys(
       {AndroidConfig? androidConfig, IosConfig? iosConfig}) async {

--- a/lib/biometric_signature_method_channel.dart
+++ b/lib/biometric_signature_method_channel.dart
@@ -19,10 +19,10 @@ class MethodChannelBiometricSignature extends BiometricSignaturePlatform {
     try {
       if (Platform.isAndroid) {
         return await methodChannel.invokeMethod<String>(
-            'createKeys', androidConfig.useDeviceCredentials);
+            'createKeys', androidConfig.toMap());
       } else {
         return await methodChannel.invokeMethod<String>(
-            'createKeys', iosConfig.useDeviceCredentials);
+            'createKeys', iosConfig.toMap());
       }
     } on PlatformException {
       rethrow;

--- a/lib/ios_config.dart
+++ b/lib/ios_config.dart
@@ -1,7 +1,16 @@
 class IosConfig {
   bool useDeviceCredentials;
+  bool enforceBiometric;
 
   IosConfig({
     required this.useDeviceCredentials,
+    this.enforceBiometric = false,
   });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'useDeviceCredentials': useDeviceCredentials,
+      'enforceBiometric': enforceBiometric,
+    };
+  }
 }

--- a/lib/ios_config.dart
+++ b/lib/ios_config.dart
@@ -1,16 +1,19 @@
 class IosConfig {
   bool useDeviceCredentials;
   bool enforceBiometric;
+  Map<String?, String?>? options;
 
   IosConfig({
     required this.useDeviceCredentials,
     this.enforceBiometric = false,
+    this.options,
   });
 
   Map<String, dynamic> toMap() {
     return {
       'useDeviceCredentials': useDeviceCredentials,
       'enforceBiometric': enforceBiometric,
+      'options': options,
     };
   }
 }


### PR DESCRIPTION
This PR adds support for doing authentication with biometric before generating key-pair. This feature adds more security so key-pair is only generated if biometric is done successfully. 

It uses enforceBiometric parameter in AndroidConfig and IosConfig. The parameter defaults to false.

PR also updates documentation in code and in README but doesn't raise package version as I'm not sure what version would be next.
Thanks.

Implements what is described in: #28.