### PR TITLE
Add DomainState helper to persist/evaluate evaluatedPolicyDomainState for biometry-change detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.4.1] - 2025-09-18
+
+* Suggesting a fix for [issue](https://github.com/chamodanethra/biometric_signature/issues/39).
+
 ## [6.4.0] - 2025-09-17
 
 * Suggesting a fix for [issue](https://github.com/chamodanethra/biometric_signature/issues/36) using Kotlin coroutines.
@@ -12,6 +16,10 @@
 * Updating the README.md file descriptions.
 * Adding ECDSA Key support for cryptographic operations.
 * Suggesting a fix for [issue](https://github.com/chamodanethra/biometric_signature/issues/30).
+
+## [6.2.1] - 2025-09-17
+
+* Suggesting a fix for [issue](https://github.com/chamodanethra/biometric_signature/issues/39).
 
 ## [6.2.0] - 2025-01-15
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get started with Biometric Signature, follow these steps:
 
 ```yaml
 dependencies:
-  biometric_signature: ^6.4.0
+  biometric_signature: ^6.4.1
 ```
 
 |             | Android | iOS   |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - biometric_signature (6.4.0):
+  - biometric_signature (6.4.1):
     - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  biometric_signature: 2aae8cb75a833c79415e786984b6c1ccd6c50164
+  biometric_signature: 1e9b535b154baa0640eae7c81180757c0bc9f5ac
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "6.4.0"
+    version: "6.4.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/Classes/BiometricSignaturePlugin.swift
+++ b/ios/Classes/BiometricSignaturePlugin.swift
@@ -6,8 +6,74 @@ import Security
 private enum Constants {
     static let authFailed = "AUTH_FAILED"
     static let invalidPayload = "INVALID_PAYLOAD"
-    static let biometricKeyAlias = "biometric_key"
-    static let ecKeyAlias = "com.visionflutter.eckey".data(using: .utf8)!
+    static let biometricKeyAlias = "biometric_key"        // used for RSA blob (service/account)
+    static let ecKeyAlias = "com.visionflutter.eckey".data(using: .utf8)! // applicationTag (Data)
+}
+
+// MARK: - Domain State (biometry change detection)
+private enum DomainState {
+    static let service = "com.visionflutter.biometric_signature.domain_state"
+
+    private static func account() -> String { "biometric_domain_state_v1" }
+
+    static func saveCurrent() {
+        let ctx = LAContext()
+        var err: NSError?
+        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &err),
+              let state = ctx.evaluatedPolicyDomainState else { return }
+
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account()
+        ]
+        let attrs: [String: Any] = [kSecValueData as String: state]
+        let status = SecItemUpdate(base as CFDictionary, attrs as CFDictionary)
+        if status == errSecItemNotFound {
+            var add = base; add[kSecValueData as String] = state
+            _ = SecItemAdd(add as CFDictionary, nil)
+        }
+    }
+
+    static func loadSaved() -> Data? {
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account(),
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var out: CFTypeRef?
+        let s = SecItemCopyMatching(q as CFDictionary, &out)
+        if s == errSecSuccess, let d = out as? Data { return d }
+        return nil
+    }
+
+    @discardableResult
+    static func deleteSaved() -> Bool {
+        let q: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account()
+        ]
+        let s = SecItemDelete(q as CFDictionary)
+        return s == errSecSuccess || s == errSecItemNotFound
+    }
+
+    /// Returns true if biometry changed vs saved baseline (no UI).
+    static func biometryChangedOrUnknown() -> Bool {
+        let ctx = LAContext()
+        var laErr: NSError?
+        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &laErr),
+              let current = ctx.evaluatedPolicyDomainState else {
+            // If we can't evaluate and we *had* a baseline, be conservative.
+            return loadSaved() != nil
+        }
+        if let saved = loadSaved() { return saved != current }
+        // First run / no baseline: save now and consider valid this time.
+        saveCurrent()
+        return false
+    }
 }
 
 public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
@@ -37,14 +103,16 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         case "biometricAuthAvailable":
             biometricAuthAvailable(result: result)
         case "biometricKeyExists":
-            guard let checkValidity = call.arguments as? Bool else {
-                return
-            }
+            guard let checkValidity = call.arguments as? Bool else { return }
             biometricKeyExists(checkValidity: checkValidity, result: result)
+        case "migrateToSecureEnclave":
+            migrateToSecureEnclave(options: call.arguments as? [String: String], result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
     }
+
+    // MARK: - Public API
 
     private func biometricAuthAvailable(result: @escaping FlutterResult) {
         let context = LAContext()
@@ -53,22 +121,16 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
 
         if canEvaluatePolicy {
             let biometricType = getBiometricType(context)
-            dispatchMainAsync {
-                result(biometricType)
-            }
+            dispatchMainAsync { result(biometricType) }
         } else {
             let errorMessage = error?.localizedDescription ?? ""
-            dispatchMainAsync {
-                result("none, \(errorMessage)")
-            }
+            dispatchMainAsync { result("none, \(errorMessage)") }
         }
     }
 
     private func biometricKeyExists(checkValidity: Bool, result: @escaping FlutterResult) {
-        let biometricKeyExists = self.doesBiometricKeyExist(checkValidity: checkValidity)
-        dispatchMainAsync {
-            result(biometricKeyExists)
-        }
+        let exists = self.doesBiometricKeyExist(checkValidity: checkValidity)
+        dispatchMainAsync { result(exists) }
     }
 
     private func deleteKeys(result: @escaping FlutterResult) {
@@ -90,11 +152,13 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         ]
         let rsaStatus = SecItemDelete(encryptedKeyQuery as CFDictionary)
 
-        let success = (ecStatus == errSecSuccess || ecStatus == errSecItemNotFound) &&
-                      (rsaStatus == errSecSuccess || rsaStatus == errSecItemNotFound)
-        dispatchMainAsync {
-            result(success)
-        }
+        // Delete saved domain-state baseline
+        let dsOK = DomainState.deleteSaved()
+
+        let success = (ecStatus == errSecSuccess || ecStatus == errSecItemNotFound)
+                   && (rsaStatus == errSecSuccess || rsaStatus == errSecItemNotFound)
+                   && dsOK
+        dispatchMainAsync { result(success) }
     }
 
     private func deleteExistingKeys() {
@@ -115,10 +179,13 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
             kSecAttrAccount as String: encryptedKeyTag
         ]
         SecItemDelete(encryptedKeyQuery as CFDictionary)
+
+        // Also delete the baseline to keep invariant: no baseline without keys
+        _ = DomainState.deleteSaved()
     }
 
     private func createKeys(useDeviceCredentials: Bool, useEc: Bool, result: @escaping FlutterResult) {
-        // Delete existing keys
+        // Delete existing keys (and baseline)
         deleteExistingKeys()
 
         // Generate EC key pair in Secure Enclave
@@ -127,7 +194,7 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         let ecAccessControl = SecAccessControlCreateWithFlags(
             kCFAllocatorDefault,
             kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-            [.privateKeyUsage, useDeviceCredentials ? .userPresence: .biometryAny],
+            [.privateKeyUsage, useDeviceCredentials ? .userPresence : .biometryAny],
             nil
         )
 
@@ -141,7 +208,6 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         }
 
         let ecTag = Constants.ecKeyAlias
-
         let ecKeyAttributes: [String: Any] = [
             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
             kSecAttrKeySizeInBits as String: 256,
@@ -156,52 +222,40 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         var error: Unmanaged<CFError>?
         guard let ecPrivateKey = SecKeyCreateRandomKey(ecKeyAttributes as CFDictionary, &error) else {
             dispatchMainAsync {
-                let errorDescription = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error generating EC key: \(errorDescription)",
-                                    details: nil))
+                let msg = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
+                result(FlutterError(code: Constants.authFailed, message: "Error generating EC key: \(msg)", details: nil))
             }
             return
         }
 
         guard let ecPublicKey = SecKeyCopyPublicKey(ecPrivateKey) else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error getting EC public key",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "Error getting EC public key", details: nil))
             }
             return
         }
+
+        // Persist domain-state baseline right after successful EC creation
+        DomainState.saveCurrent()
 
         if useEc {
-            // EC-only mode: return the EC public key directly
-            // Use SecKeyCopyExternalRepresentation with proper format
+            // EC-only: return EC public key (X9.63 uncompressed + header)
             let publicKeyString = getPublicKeyString(ecPublicKey)
-            dispatchMainAsync {
-                result(publicKeyString)
-            }
+            dispatchMainAsync { result(publicKeyString) }
             return
         }
 
-        // Generate RSA key pair
-        let rsaKeyAttributes: [String: Any] = ([
-            kSecAttrKeyType as AnyHashable: kSecAttrKeyTypeRSA,
-            kSecAttrKeySizeInBits as AnyHashable: NSNumber(value: 2048),
-            kSecPrivateKeyAttrs as AnyHashable: [
-                kSecAttrIsPermanent as AnyHashable: NSNumber(value: false),
-            ] as Any
-        ] as CFDictionary) as! [String : Any]
+        // --- Hybrid path: generate RSA and wrap its private key with ECIES(X9.63/SHA-256/AES-GCM)
+        let rsaKeyAttributes: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeySizeInBits as String: 2048,
+            kSecPrivateKeyAttrs as String: [kSecAttrIsPermanent as String: false]
+        ]
 
-        var rsaPrivateKey: SecKey?
-        rsaPrivateKey = SecKeyCreateRandomKey(rsaKeyAttributes as CFDictionary, &error)
-
-        guard let rsaPrivate = rsaPrivateKey,
-              let rsaPublicKey = SecKeyCopyPublicKey(rsaPrivate)
-        else {
+        guard let rsaPrivate = SecKeyCreateRandomKey(rsaKeyAttributes as CFDictionary, &error),
+              let rsaPublicKey = SecKeyCopyPublicKey(rsaPrivate) else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error generating RSA key pair",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "Error generating RSA key pair", details: nil))
             }
             return
         }
@@ -209,9 +263,7 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         // Extract RSA private key data
         guard let rsaPrivateKeyData = SecKeyCopyExternalRepresentation(rsaPrivate, &error) as Data? else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error extracting RSA private key data",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "Error extracting RSA private key data", details: nil))
             }
             return
         }
@@ -220,23 +272,15 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         let algorithm: SecKeyAlgorithm = .eciesEncryptionStandardX963SHA256AESGCM
         guard SecKeyIsAlgorithmSupported(ecPublicKey, .encrypt, algorithm) else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "EC encryption algorithm not supported",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "EC encryption algorithm not supported", details: nil))
             }
             return
         }
 
-        guard let encryptedRSAKeyData = SecKeyCreateEncryptedData(ecPublicKey,
-                                                                  algorithm,
-                                                                  rsaPrivateKeyData as CFData,
-                                                                  &error) as Data?
-        else {
-            let errorDescription = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
+        guard let encryptedRSAKeyData = SecKeyCreateEncryptedData(ecPublicKey, algorithm, rsaPrivateKeyData as CFData, &error) as Data? else {
+            let msg = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error encrypting RSA private key: \(errorDescription)",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "Error encrypting RSA private key: \(msg)", details: nil))
             }
             return
         }
@@ -250,33 +294,25 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
             kSecValueData as String: encryptedRSAKeyData,
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
-
         SecItemDelete(encryptedKeyAttributes as CFDictionary) // Delete existing item
         let status = SecItemAdd(encryptedKeyAttributes as CFDictionary, nil)
-        if status != errSecSuccess {
+        guard status == errSecSuccess else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error storing encrypted RSA private key in Keychain",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "Error storing encrypted RSA private key in Keychain", details: nil))
             }
             return
         }
 
         // Get RSA public key data
         let publicKeyString = getPublicKeyString(rsaPublicKey)
-        dispatchMainAsync {
-            result(publicKeyString)
-        }
+        dispatchMainAsync { result(publicKeyString) }
     }
 
     private func createSignature(options: [String: String]?, result: @escaping FlutterResult) {
         let promptMessage = options?["promptMessage"] ?? "Authenticate to sign data"
-        guard let payload = options?["payload"],
-              let dataToSign = payload.data(using: .utf8) else {
+        guard let payload = options?["payload"], let dataToSign = payload.data(using: .utf8) else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.invalidPayload,
-                                    message: "Payload is required and must be valid UTF-8",
-                                    details: nil))
+                result(FlutterError(code: Constants.invalidPayload, message: "Payload is required and must be valid UTF-8", details: nil))
             }
             return
         }
@@ -290,10 +326,8 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
-
         var item: CFTypeRef?
         let status = SecItemCopyMatching(encryptedKeyQuery as CFDictionary, &item)
-
         if status != errSecSuccess {
             // No RSA key found, try EC-only mode
             createECSignature(dataToSign: dataToSign, promptMessage: promptMessage, result: result)
@@ -303,9 +337,7 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         // 1. Retrieve encrypted RSA private key from Keychain
         guard let encryptedRSAKeyData = item as? Data else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Failed to retrieve encrypted RSA key data",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "Failed to retrieve encrypted RSA key data", details: nil))
             }
             return
         }
@@ -315,115 +347,6 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         //    and rely on iOS to prompt for authentication when
         //    we pass "kSecUseOperationPrompt".
         let ecTag = Constants.ecKeyAlias
-
-        let ecKeyQuery: [String: Any] = [
-            kSecClass as String: kSecClassKey,
-            kSecAttrApplicationTag as String: ecTag,
-            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-            kSecReturnRef as String: true,
-            // kSecUseAuthenticationContext as String: context,
-            kSecUseOperationPrompt as String: promptMessage
-        ]
-
-    var ecPrivateKeyRef: CFTypeRef?
-    let ecStatus = SecItemCopyMatching(ecKeyQuery as CFDictionary, &ecPrivateKeyRef)
-    guard ecStatus == errSecSuccess else {
-        dispatchMainAsync {
-            result(FlutterError(code: Constants.authFailed, message: "EC private key not found", details: nil))
-        }
-        return
-    }
-    guard let ecPrivateKeyRef = ecPrivateKeyRef else {
-        dispatchMainAsync {
-            result(FlutterError(code: Constants.authFailed, message: "Failed to retrieve EC private key reference", details: nil))
-        }
-        return
-    }
-    let ecPrivateKey = ecPrivateKeyRef as! SecKey
-
-        // 3. Decrypt RSA private key data using the EC private key
-        let algorithm: SecKeyAlgorithm = .eciesEncryptionStandardX963SHA256AESGCM
-        guard SecKeyIsAlgorithmSupported(ecPrivateKey, .decrypt, algorithm) else {
-            dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "EC decryption algorithm not supported",
-                                    details: nil))
-            }
-            return
-        }
-
-        var error: Unmanaged<CFError>?
-        guard var rsaPrivateKeyData = SecKeyCreateDecryptedData(ecPrivateKey,
-                                                                algorithm,
-                                                                encryptedRSAKeyData as CFData,
-                                                                &error) as Data?
-        else {
-            let errorDescription = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
-            dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error decrypting RSA private key: \(errorDescription)",
-                                    details: nil))
-            }
-            return
-        }
-
-        // 4. Reconstruct RSA private key from data
-        let rsaKeyAttributes: [String: Any] = [
-            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
-            kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
-            kSecAttrKeySizeInBits as String: 2048
-        ]
-
-        guard let rsaPrivateKey = SecKeyCreateWithData(rsaPrivateKeyData as CFData,
-                                                       rsaKeyAttributes as CFDictionary,
-                                                       &error)
-        else {
-            let errorDescription = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
-            dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error reconstructing RSA private key: \(errorDescription)",
-                                    details: nil))
-            }
-            return
-        }
-
-        // 5. Sign data with RSA private key
-        let signAlgorithm = SecKeyAlgorithm.rsaSignatureMessagePKCS1v15SHA256
-        guard SecKeyIsAlgorithmSupported(rsaPrivateKey, .sign, signAlgorithm) else {
-            dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "RSA signing algorithm not supported",
-                                    details: nil))
-            }
-            return
-        }
-
-        guard let signature = SecKeyCreateSignature(rsaPrivateKey,
-                                                    signAlgorithm,
-                                                    dataToSign as CFData,
-                                                    &error) as Data?
-        else {
-            let errorDescription = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
-            dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error signing data: \(errorDescription)",
-                                    details: nil))
-            }
-            return
-        }
-
-        // 6. Zero out decrypted RSA private key data
-        rsaPrivateKeyData.resetBytes(in: 0..<rsaPrivateKeyData.count)
-
-        dispatchMainAsync {
-            result(signature.base64EncodedString())
-        }
-    }
-
-    private func createECSignature(dataToSign: Data, promptMessage: String, result: @escaping FlutterResult) {
-        // Retrieve EC private key from Secure Enclave
-        let ecTag = Constants.ecKeyAlias
-
         let ecKeyQuery: [String: Any] = [
             kSecClass as String: kSecClassKey,
             kSecAttrApplicationTag as String: ecTag,
@@ -434,15 +357,84 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
 
         var ecPrivateKeyRef: CFTypeRef?
         let ecStatus = SecItemCopyMatching(ecKeyQuery as CFDictionary, &ecPrivateKeyRef)
-        guard ecStatus == errSecSuccess else {
+        guard ecStatus == errSecSuccess, let ecPrivateKeyRef = ecPrivateKeyRef else {
             dispatchMainAsync {
                 result(FlutterError(code: Constants.authFailed, message: "EC private key not found", details: nil))
             }
             return
         }
-        guard let ecPrivateKeyRef = ecPrivateKeyRef else {
+        let ecPrivateKey = ecPrivateKeyRef as! SecKey
+
+        // 3. Decrypt RSA private key data using the EC private key
+        let algorithm: SecKeyAlgorithm = .eciesEncryptionStandardX963SHA256AESGCM
+        guard SecKeyIsAlgorithmSupported(ecPrivateKey, .decrypt, algorithm) else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed, message: "Failed to retrieve EC private key reference", details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "EC decryption algorithm not supported", details: nil))
+            }
+            return
+        }
+
+        var error: Unmanaged<CFError>?
+        guard var rsaPrivateKeyData = SecKeyCreateDecryptedData(ecPrivateKey, algorithm, encryptedRSAKeyData as CFData, &error) as Data? else {
+            let msg = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
+            dispatchMainAsync {
+                result(FlutterError(code: Constants.authFailed, message: "Error decrypting RSA private key: \(msg)", details: nil))
+            }
+            return
+        }
+
+        // 4. Reconstruct RSA private key from data
+        let rsaKeyAttributes: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
+            kSecAttrKeySizeInBits as String: 2048
+        ]
+        guard let rsaPrivateKey = SecKeyCreateWithData(rsaPrivateKeyData as CFData, rsaKeyAttributes as CFDictionary, &error) else {
+            let msg = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
+            dispatchMainAsync {
+                result(FlutterError(code: Constants.authFailed, message: "Error reconstructing RSA private key: \(msg)", details: nil))
+            }
+            return
+        }
+
+        // 5. Sign data with RSA private key
+        let signAlgorithm = SecKeyAlgorithm.rsaSignatureMessagePKCS1v15SHA256
+        guard SecKeyIsAlgorithmSupported(rsaPrivateKey, .sign, signAlgorithm) else {
+            dispatchMainAsync {
+                result(FlutterError(code: Constants.authFailed, message: "RSA signing algorithm not supported", details: nil))
+            }
+            return
+        }
+
+        guard let signature = SecKeyCreateSignature(rsaPrivateKey, signAlgorithm, dataToSign as CFData, &error) as Data? else {
+            let msg = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
+            dispatchMainAsync {
+                result(FlutterError(code: Constants.authFailed, message: "Error signing data: \(msg)", details: nil))
+            }
+            return
+        }
+
+        // Zero the decrypted RSA private key bytes in-memory
+        rsaPrivateKeyData.resetBytes(in: 0..<rsaPrivateKeyData.count)
+
+        dispatchMainAsync { result(signature.base64EncodedString()) }
+    }
+
+    private func createECSignature(dataToSign: Data, promptMessage: String, result: @escaping FlutterResult) {
+        // Retrieve EC private key from Secure Enclave
+        let ecTag = Constants.ecKeyAlias
+        let ecKeyQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: ecTag,
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecReturnRef as String: true,
+            kSecUseOperationPrompt as String: promptMessage
+        ]
+        var ecPrivateKeyRef: CFTypeRef?
+        let ecStatus = SecItemCopyMatching(ecKeyQuery as CFDictionary, &ecPrivateKeyRef)
+        guard ecStatus == errSecSuccess, let ecPrivateKeyRef = ecPrivateKeyRef else {
+            dispatchMainAsync {
+                result(FlutterError(code: Constants.authFailed, message: "EC private key not found", details: nil))
             }
             return
         }
@@ -452,41 +444,31 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin {
         let signAlgorithm = SecKeyAlgorithm.ecdsaSignatureMessageX962SHA256
         guard SecKeyIsAlgorithmSupported(ecPrivateKey, .sign, signAlgorithm) else {
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "EC signing algorithm not supported",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "EC signing algorithm not supported", details: nil))
             }
             return
         }
 
         var error: Unmanaged<CFError>?
-        guard let signature = SecKeyCreateSignature(ecPrivateKey,
-                                                    signAlgorithm,
-                                                    dataToSign as CFData,
-                                                    &error) as Data?
-        else {
-            let errorDescription = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
+        guard let signature = SecKeyCreateSignature(ecPrivateKey, signAlgorithm, dataToSign as CFData, &error) as Data? else {
+            let msg = error?.takeRetainedValue().localizedDescription ?? "Unknown error"
             dispatchMainAsync {
-                result(FlutterError(code: Constants.authFailed,
-                                    message: "Error signing data with EC key: \(errorDescription)",
-                                    details: nil))
+                result(FlutterError(code: Constants.authFailed, message: "Error signing data with EC key: \(msg)", details: nil))
             }
             return
         }
 
-        dispatchMainAsync {
-            result(signature.base64EncodedString())
-        }
+        dispatchMainAsync { result(signature.base64EncodedString()) }
     }
 
-private func migrateToSecureEnclave(options: [String: String]?, result: @escaping FlutterResult) {
-    // Generate EC key pair in Secure Enclave
-    let ecAccessControl = SecAccessControlCreateWithFlags(
-        kCFAllocatorDefault,
-        kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-        [.privateKeyUsage, .biometryAny],
-        nil
-    )
+    private func migrateToSecureEnclave(options: [String: String]?, result: @escaping FlutterResult) {
+        // Generate EC key pair in Secure Enclave
+        let ecAccessControl = SecAccessControlCreateWithFlags(
+            kCFAllocatorDefault,
+            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+            [.privateKeyUsage, .biometryAny],
+            nil
+        )
 
         guard let ecAccessControl = ecAccessControl else {
             dispatchMainAsync {
@@ -496,7 +478,6 @@ private func migrateToSecureEnclave(options: [String: String]?, result: @escapin
         }
 
         let ecTag = Constants.ecKeyAlias
-
         let ecKeyAttributes: [String: Any] = [
             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
             kSecAttrKeySizeInBits as String: 256,
@@ -523,6 +504,9 @@ private func migrateToSecureEnclave(options: [String: String]?, result: @escapin
             }
             return
         }
+
+        // Save baseline after EC key creation
+        DomainState.saveCurrent()
 
         let unencryptedKeyTag = getBiometricKeyTag()
         let unencryptedKeyQuery: [String: Any] = [
@@ -603,6 +587,7 @@ private func migrateToSecureEnclave(options: [String: String]?, result: @escapin
     }
 
     private func doesBiometricKeyExist(checkValidity: Bool = false) -> Bool {
+        // Check EC key existence
         let ecTag = Constants.ecKeyAlias
         let ecKeyQuery: [String: Any] = [
             kSecClass as String: kSecClassKey,
@@ -628,67 +613,32 @@ private func migrateToSecureEnclave(options: [String: String]?, result: @escapin
 
         // For EC-only mode, only EC key needs to exist
         if ecKeyExists && !rsaKeyExists {
-            if !checkValidity {
-                return true
-            }
-            // Validate EC key by checking if it supports signing
-            guard let ecItem = ecItem else {
-                return false
-            }
-            let ecPrivateKey = ecItem as! SecKey
-            return SecKeyIsAlgorithmSupported(ecPrivateKey, .sign, .ecdsaSignatureMessageX962SHA256)
+            guard checkValidity else { return true }
+            // Non-interactive validity: return false if biometry changed
+            return !DomainState.biometryChangedOrUnknown()
         }
 
-        // For hybrid mode, both keys must exist
-        if !ecKeyExists || !rsaKeyExists {
-            return false
-        }
+        // Hybrid: both must exist
+        guard ecKeyExists, rsaKeyExists else { return false }
+        guard checkValidity else { return true }
 
-        if !checkValidity {
-            return true
-        }
-
-        // Validate the EC key by attempting to decrypt the RSA key
-        guard let ecItem = ecItem else {
-            return false
-        }
-        let ecPrivateKey = ecItem as! SecKey
-
-        let algorithm: SecKeyAlgorithm = .eciesEncryptionStandardX963SHA256AESGCM
-        guard SecKeyIsAlgorithmSupported(ecPrivateKey, .decrypt, algorithm) else {
-            return false
-        }
-
-        guard rsaItem is Data else {
-            return false
-        }
-        return true
+        // Non-interactive validity for hybrid: domain-state compare
+        return !DomainState.biometryChangedOrUnknown()
     }
 
     private func getBiometricKeyTag() -> Data {
         let BIOMETRIC_KEY_ALIAS = Constants.biometricKeyAlias
-        let tag = BIOMETRIC_KEY_ALIAS.data(using: .utf8)
-        return tag!
+        return BIOMETRIC_KEY_ALIAS.data(using: .utf8)!
     }
 
     private func getPublicKeyString(_ publicKey: SecKey) -> String {
         var error: Unmanaged<CFError>?
-
         if let publicKeyData = SecKeyCopyExternalRepresentation(publicKey, &error) as Data? {
             // Check if it's an EC key by looking at the key size (EC keys are typically 65 bytes for secp256r1)
             let isEc = publicKeyData.count == 65
-
-            if isEc {
-                // Use the existing addHeader method for EC keys
-                let publicKeyDataWithHeader = BiometricSignaturePlugin.addHeader(publicKeyData: publicKeyData, isEc: true)
-                return publicKeyDataWithHeader?.base64EncodedString() ?? ""
-            } else {
-                // Use the existing addHeader method for RSA keys
-                let publicKeyDataWithHeader = BiometricSignaturePlugin.addHeader(publicKeyData: publicKeyData, isEc: false)
-                return publicKeyDataWithHeader?.base64EncodedString() ?? ""
-            }
+            let withHeader = BiometricSignaturePlugin.addHeader(publicKeyData: publicKeyData, isEc: isEc)
+            return withHeader?.base64EncodedString() ?? ""
         }
-
         return ""
     }
 
@@ -697,32 +647,22 @@ private func migrateToSecureEnclave(options: [String: String]?, result: @escapin
     ]
 
     private static let encodedECEncryptionOID: [UInt8] = [
-        0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07
+        0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08,
+        0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07
     ]
 
     private static func addHeader(publicKeyData: Data?, isEc: Bool = false) -> Data? {
         guard let publicKeyData = publicKeyData else { return nil }
-
-        if isEc {
-            return addECHeader(publicKeyData: publicKeyData)
-        } else {
-            return addRSAHeader(publicKeyData: publicKeyData)
-        }
+        return isEc ? addECHeader(publicKeyData: publicKeyData) : addRSAHeader(publicKeyData: publicKeyData)
     }
 
     private static func addRSAHeader(publicKeyData: Data?) -> Data? {
         guard let publicKeyData = publicKeyData else { return nil }
-
         var builder = [UInt8](repeating: 0, count: 15)
         var encKey = Data()
-        let bitstringEncLength: UInt
-        if publicKeyData.count + 1 < 128 {
-            bitstringEncLength = 1
-        } else {
-            bitstringEncLength = UInt(((publicKeyData.count + 1) / 256) + 2)
-        }
+        let bitLen: UInt = (publicKeyData.count + 1 < 128) ? 1 : UInt(((publicKeyData.count + 1) / 256) + 2)
         builder[0] = 0x30
-        let i = encodedRSAEncryptionOID.count + 2 + Int(bitstringEncLength) + publicKeyData.count
+        let i = encodedRSAEncryptionOID.count + 2 + Int(bitLen) + publicKeyData.count
         var j = encodedLength(&builder[1], i)
         encKey.append(&builder, count: Int(j + 1))
         encKey.append(encodedRSAEncryptionOID, count: encodedRSAEncryptionOID.count)
@@ -736,17 +676,11 @@ private func migrateToSecureEnclave(options: [String: String]?, result: @escapin
 
     private static func addECHeader(publicKeyData: Data?) -> Data? {
         guard let publicKeyData = publicKeyData else { return nil }
-
         var builder = [UInt8](repeating: 0, count: 15)
         var encKey = Data()
-        let bitstringEncLength: UInt
-        if publicKeyData.count + 1 < 128 {
-            bitstringEncLength = 1
-        } else {
-            bitstringEncLength = UInt(((publicKeyData.count + 1) / 256) + 2)
-        }
+        let bitLen: UInt = (publicKeyData.count + 1 < 128) ? 1 : UInt(((publicKeyData.count + 1) / 256) + 2)
         builder[0] = 0x30
-        let i = encodedECEncryptionOID.count + 2 + Int(bitstringEncLength) + publicKeyData.count
+        let i = encodedECEncryptionOID.count + 2 + Int(bitLen) + publicKeyData.count
         var j = encodedLength(&builder[1], i)
         encKey.append(&builder, count: Int(j + 1))
         encKey.append(encodedECEncryptionOID, count: encodedECEncryptionOID.count)
@@ -758,8 +692,7 @@ private func migrateToSecureEnclave(options: [String: String]?, result: @escapin
         return encKey
     }
 
-    private static func encodedLength(_ buf: UnsafeMutablePointer<UInt8>?,
-                                      _ length: size_t) -> size_t {
+    private static func encodedLength(_ buf: UnsafeMutablePointer<UInt8>?, _ length: size_t) -> size_t {
         var length = length
         if length < 128 {
             buf?[0] = UInt8(length)

--- a/ios/biometric_signature.podspec
+++ b/ios/biometric_signature.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'biometric_signature'
-  s.version          = '6.4.0'
+  s.version          = '6.4.1'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: biometric_signature
 description: Flutter biometric functionality for cryptographic signing and encryption using the Secure Enclave and the StrongBox
-version: 6.4.0
+version: 6.4.1
 homepage: https://github.com/chamodanethra/biometric_signature
 
 environment:


### PR DESCRIPTION

- Add DomainState helper to persist/evaluate evaluatedPolicyDomainState for biometry-change detection
- Save domain-state baseline after EC key creation and during migration; delete baseline when keys are removed
- Use domain-state for non-interactive key validity checks (doesBiometricKeyExist)
- Refactor BiometricSignaturePlugin.swift: simplify guards/errors, compact dispatchMainAsync calls, zero decrypted RSA bytes, tighten SecItem handling, and small API additions (migrateToSecureEnclave)
- Update public headers/encoding helpers for key export formatting and minor performance/format fixes
- Bump version to 6.4.1 in pubspec, podspec, README and update example lockfiles and CHANGELOG