### PR TITLE
Bump version to 12.0.1 and fix Android prompt customization and ProGuard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [12.0.1] - 2026-05-28
+
+### Fixed
+* **Android prompt customization fields are now honored on `createKeys`, `createSignature`, and `decrypt`.** The Dart API and Pigeon schema have always exposed `promptSubtitle`, `promptDescription`, and `cancelButtonText` on `CreateKeysConfig` / `CreateSignatureConfig` / `DecryptConfig`, and the README documented them, but the Android plugin was silently dropping them — `createKeys` and `decrypt` hard-coded `null, null, "Cancel"` into the `BiometricPrompt`, and `createSignature` hard-coded `null` for the description. All three are now threaded through to `BiometricPrompt.PromptInfo.Builder`. Fixes [#67](https://github.com/chamodanethra/biometric_signature/issues/67).
+* **Release-build biometric type detection on Android.** Added ProGuard/R8 keep rules for `androidx.biometric.BiometricManager#getStrings(int)` and `BiometricManager$Strings#getButtonLabel()` / `getPromptMessage()` / `getSettingButtonLabel()`, which are invoked via reflection by `BiometricPromptHelper.detectBiometricTypes` to disambiguate face/fingerprint/iris on devices that advertise multiple BIOMETRIC_STRONG modalities. Without these rules, R8 would rename or strip the methods in release builds and the label-matching path would silently fall back to feature-flag-only detection.
+
 ## [12.0.0] - 2026-05-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To get started with Biometric Signature, follow these steps:
 
 ```yaml
 dependencies:
-  biometric_signature: ^12.0.0
+  biometric_signature: ^12.0.1
 ```
 
 |             | Android | iOS   | macOS  | Windows |

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -12,3 +12,13 @@
 
 # Keep class names only (not members) for readable stack traces
 -keepnames class com.visionflutter.biometric_signature.**
+
+# Keep reflection targets in androidx.biometric for detecting biometric types
+-keep class androidx.biometric.BiometricManager {
+    *** getStrings(...);
+}
+-keep class androidx.biometric.BiometricManager$Strings {
+    *** getButtonLabel(...);
+    *** getPromptMessage(...);
+    *** getSettingButtonLabel(...);
+}

--- a/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignaturePlugin.kt
+++ b/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignaturePlugin.kt
@@ -146,11 +146,14 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
                 }
 
                 val prompt = promptMessage ?: "Authenticate to create keys"
+                val promptSubtitle = config?.promptSubtitle
+                val promptDescription = config?.promptDescription
+                val cancelButtonText = config?.cancelButtonText ?: "Cancel"
 
                 when (mode) {
-                    KeyMode.RSA -> createRsaKeys(act, keyAlias, callback, useDeviceCredentials, invalidateOnEnrollment, enableDecryption, enforceBiometric, keyFormat, prompt)
-                    KeyMode.EC_SIGN_ONLY -> createEcSigningKeys(act, keyAlias, callback, useDeviceCredentials, invalidateOnEnrollment, enforceBiometric, keyFormat, prompt)
-                    KeyMode.HYBRID_EC -> createHybridEcKeys(act, keyAlias, callback, useDeviceCredentials, invalidateOnEnrollment, keyFormat, enforceBiometric, prompt)
+                    KeyMode.RSA -> createRsaKeys(act, keyAlias, callback, useDeviceCredentials, invalidateOnEnrollment, enableDecryption, enforceBiometric, keyFormat, prompt, promptSubtitle, promptDescription, cancelButtonText)
+                    KeyMode.EC_SIGN_ONLY -> createEcSigningKeys(act, keyAlias, callback, useDeviceCredentials, invalidateOnEnrollment, enforceBiometric, keyFormat, prompt, promptSubtitle, promptDescription, cancelButtonText)
+                    KeyMode.HYBRID_EC -> createHybridEcKeys(act, keyAlias, callback, useDeviceCredentials, invalidateOnEnrollment, keyFormat, enforceBiometric, prompt, promptSubtitle, promptDescription, cancelButtonText)
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -176,13 +179,16 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
         enableDecryption: Boolean,
         enforceBiometric: Boolean,
         keyFormat: KeyFormat,
-        promptMessage: String
+        promptMessage: String,
+        promptSubtitle: String?,
+        promptDescription: String?,
+        cancelButtonText: String
     ) {
         var authType: AuthenticationType? = null
         if (enforceBiometric) {
             biometricPromptHelper.checkBiometricAvailability(activity, useDeviceCredentials)
             val outcome = biometricPromptHelper.authenticate(
-                activity, promptMessage, null, null, "Cancel",
+                activity, promptMessage, promptSubtitle, promptDescription, cancelButtonText,
                 useDeviceCredentials, null
             )
             authType = outcome.authenticationType
@@ -205,13 +211,16 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
         invalidateOnEnrollment: Boolean,
         enforceBiometric: Boolean,
         keyFormat: KeyFormat,
-        promptMessage: String
+        promptMessage: String,
+        promptSubtitle: String?,
+        promptDescription: String?,
+        cancelButtonText: String
     ) {
         var authType: AuthenticationType? = null
         if (enforceBiometric) {
             biometricPromptHelper.checkBiometricAvailability(activity, useDeviceCredentials)
             val outcome = biometricPromptHelper.authenticate(
-                activity, promptMessage, null, null, "Cancel",
+                activity, promptMessage, promptSubtitle, promptDescription, cancelButtonText,
                 useDeviceCredentials, null
             )
             authType = outcome.authenticationType
@@ -234,12 +243,15 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
         invalidateOnEnrollment: Boolean,
         keyFormat: KeyFormat,
         enforceBiometric: Boolean,
-        promptMessage: String
+        promptMessage: String,
+        promptSubtitle: String?,
+        promptDescription: String?,
+        cancelButtonText: String
     ) {
         if (enforceBiometric) {
             biometricPromptHelper.checkBiometricAvailability(activity, useDeviceCredentials)
             biometricPromptHelper.authenticate(
-                activity, promptMessage, null, null, "Cancel",
+                activity, promptMessage, promptSubtitle, promptDescription, cancelButtonText,
                 useDeviceCredentials, null
             )
         }
@@ -256,7 +268,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
 
             biometricPromptHelper.checkBiometricAvailability(activity, useDeviceCredentials)
             val wrapSuccess = biometricPromptHelper.authenticate(
-                activity, promptMessage, null, null, "Cancel",
+                activity, promptMessage, promptSubtitle, promptDescription, cancelButtonText,
                 useDeviceCredentials, BiometricPrompt.CryptoObject(cipherForWrap)
             )
 
@@ -320,7 +332,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
                 biometricPromptHelper.checkBiometricAvailability(act, allowDeviceCredentials)
 
                 val successOutcome = biometricPromptHelper.authenticate(
-                    act, promptMessage ?: "Authenticate", config?.promptSubtitle, null,
+                    act, promptMessage ?: "Authenticate", config?.promptSubtitle, config?.promptDescription,
                     config?.cancelButtonText ?: "Cancel", allowDeviceCredentials, cryptoObject
                 )
 
@@ -377,11 +389,12 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
                 val allowDeviceCredentials = config?.allowDeviceCredentials ?: false
                 val prompt = promptMessage ?: "Authenticate"
                 val subtitle = config?.promptSubtitle
+                val description = config?.promptDescription
                 val cancel = config?.cancelButtonText ?: "Cancel"
 
                 val success = when (mode) {
-                    KeyMode.RSA -> decryptRsa(act, keyAlias, payload, payloadFormat, prompt, subtitle, cancel, allowDeviceCredentials)
-                    KeyMode.HYBRID_EC -> decryptHybridEc(act, keyAlias, payload, payloadFormat, prompt, subtitle, cancel, allowDeviceCredentials)
+                    KeyMode.RSA -> decryptRsa(act, keyAlias, payload, payloadFormat, prompt, subtitle, description, cancel, allowDeviceCredentials)
+                    KeyMode.HYBRID_EC -> decryptHybridEc(act, keyAlias, payload, payloadFormat, prompt, subtitle, description, cancel, allowDeviceCredentials)
                     else -> throw SecurityException("Unsupported decryption mode")
                 }
 
@@ -408,6 +421,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
         payloadFormat: PayloadFormat,
         prompt: String,
         subtitle: String?,
+        description: String?,
         cancel: String,
         allowDeviceCredentials: Boolean
     ): DecryptSuccess {
@@ -430,7 +444,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
         biometricPromptHelper.checkBiometricAvailability(activity, allowDeviceCredentials)
 
         val successOutcome = biometricPromptHelper.authenticate(
-            activity, prompt, subtitle, null, cancel, allowDeviceCredentials,
+            activity, prompt, subtitle, description, cancel, allowDeviceCredentials,
             BiometricPrompt.CryptoObject(cipher)
         )
 
@@ -455,6 +469,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
         payloadFormat: PayloadFormat,
         prompt: String,
         subtitle: String?,
+        description: String?,
         cancel: String,
         allowDeviceCredentials: Boolean
     ): DecryptSuccess {
@@ -464,7 +479,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
         biometricPromptHelper.checkBiometricAvailability(activity, allowDeviceCredentials)
 
         val successOutcome = biometricPromptHelper.authenticate(
-            activity, prompt, subtitle, null, cancel, allowDeviceCredentials,
+            activity, prompt, subtitle, description, cancel, allowDeviceCredentials,
             BiometricPrompt.CryptoObject(cipher)
         )
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -27,6 +27,7 @@ migrate_working_dir/
 **/doc/api/
 **/ios/Flutter/.last_build_id
 .dart_tool/
+.flutter-plugins
 .flutter-plugins-dependencies
 .pub-cache/
 .pub/

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - biometric_signature (12.0.0):
+  - biometric_signature (12.0.1):
     - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  biometric_signature: b415be9f71ede8232c5bd7bd57fbaea3fc8e6550
+  biometric_signature: 696515eec525afffe5fc782a18b2722ecab2c9d8
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,7 +23,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
       home: Scaffold(
-        appBar: AppBar(title: const Text('Biometric Signature v12.0.0')),
+        appBar: AppBar(title: const Text('Biometric Signature v12.0.1')),
         body: const ExampleAppBody(),
       ),
     );

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - biometric_signature (12.0.0):
+  - biometric_signature (12.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
 
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
 
 SPEC CHECKSUMS:
-  biometric_signature: bb09af2cbcf228a3913882fe0431c3e364ff0aa2
+  biometric_signature: 2138a43f21b62c9c6600a68edcc41545b277f2a8
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "12.0.0"
+    version: "12.0.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/biometric_signature.podspec
+++ b/ios/biometric_signature.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'biometric_signature'
-  s.version          = '12.0.0'
+  s.version          = '12.0.1'
   s.summary          = 'Hardware-backed biometric signatures for Flutter.'
   s.description      = <<-DESC
 Create cryptographic signatures using Secure Enclave, StrongBox, and Windows Hello.

--- a/macos/biometric_signature.podspec
+++ b/macos/biometric_signature.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'biometric_signature'
-  s.version          = '12.0.0'
+  s.version          = '12.0.1'
   s.summary          = 'Hardware-backed biometric signatures for Flutter.'
   s.description      = <<-DESC
 Create cryptographic signatures using Secure Enclave, StrongBox, and Windows Hello.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: biometric_signature
 description: Hardware-backed biometric authentication for Flutter (Android, iOS, macOS, Windows). Create cryptographic signatures using Secure Enclave, StrongBox, and Windows Hello.
 topics: [biometrics, secure-enclave, strongbox, rsa, ecdsa]
-version: 12.0.0
+version: 12.0.1
 homepage: https://github.com/chamodanethra/biometric_signature
 
 environment:


### PR DESCRIPTION
- Fix Android implementation to honor `promptSubtitle`, `promptDescription`, and `cancelButtonText` across `createKeys`, `createSignature`, and `decrypt` methods.
- Add ProGuard keep rules for `androidx.biometric.BiometricManager` to ensure biometric type detection works correctly in release builds.
- Bump version to `12.0.1` in `pubspec.yaml`, podspecs, and README.
- Update example app and lockfiles to reflect the new version.
- Update `CHANGELOG.md` with details regarding the Android prompt and ProGuard fixes.