### PR TITLE
[android] release validity-probe KeyMint operation in getKeyInfo

### DIFF
--- a/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignaturePlugin.kt
+++ b/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignaturePlugin.kt
@@ -1,6 +1,7 @@
 package com.visionflutter.biometric_signature
 
 import android.content.Context
+import android.security.keystore.KeyPermanentlyInvalidatedException
 import androidx.biometric.BiometricPrompt
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -578,15 +579,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
                     val mode = keyManager.inferKeyModeFromKeystore(keyAlias)
 
                     val isValid = if (checkValidity) {
-                        runCatching {
-                            val algorithm = when (mode) {
-                                KeyMode.RSA -> "SHA256withRSA"
-                                else -> "SHA256withECDSA"
-                            }
-                            val signature = java.security.Signature.getInstance(algorithm)
-                            signature.initSign(entry.privateKey)
-                            true
-                        }.getOrDefault(false)
+                        probeKeyValidityAndRelease(entry.privateKey, mode)
                     } else {
                         null
                     }
@@ -625,6 +618,48 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
                 callback(Result.success(KeyInfo(exists = false)))
             }
         }
+    }
+
+    /**
+     * Probes whether [privateKey] is still usable (i.e. not invalidated by new
+     * biometric enrollment) and releases the KeyMint operation immediately.
+     *
+     * Signature.initSign begins a KeyMint operation. On StrongBox the slot pool
+     * is tiny, and a probe operation left dangling until GC accumulates and
+     * triggers TOO_MANY_OPERATIONS, which makes keystore2 prune in-flight
+     * signing operations (surfacing as INVALID_OPERATION_HANDLE / pruned). We
+     * therefore drive the probe to a terminal state right away so its slot is
+     * freed now instead of at an indeterminate GC point.
+     */
+    private fun probeKeyValidityAndRelease(privateKey: PrivateKey, mode: KeyMode?): Boolean {
+        val algorithm = when (mode) {
+            KeyMode.RSA -> "SHA256withRSA"
+            else -> "SHA256withECDSA"
+        }
+        val signature = Signature.getInstance(algorithm)
+        try {
+            signature.initSign(privateKey)
+        } catch (e: KeyPermanentlyInvalidatedException) {
+            // The key was invalidated (e.g. by new biometric enrollment).
+            return false
+        } catch (e: Exception) {
+            // Could not even begin the operation: treat as not usable, matching
+            // the previous behaviour.
+            return false
+        }
+
+        // initSign opened a KeyMint operation. Drive it to a terminal state so
+        // the slot is released now rather than lingering until GC.
+        try {
+            signature.update(byteArrayOf(0))
+            signature.sign()
+        } catch (_: Exception) {
+            // A user-authentication-bound key cannot be exercised without a
+            // fresh prompt, so finish() fails here, but that failure still
+            // finalizes (and frees) the operation. The key itself is valid: it
+            // was not KeyPermanentlyInvalidated above.
+        }
+        return true
     }
 
     override fun simplePrompt(


### PR DESCRIPTION
getKeyInfo(checkValidity=true) called Signature.initSign() to detect key invalidation but never finished/aborted the operation, leaking a KeyMint operation until GC. On StrongBox (Titan M2) the operation slot pool is tiny, so leaked probes accumulate, trigger TOO_MANY_OPERATIONS, and make keystore2 prune in-flight signing operations (INVALID_OPERATION_HANDLE / outcome: Pruned). hasToReEnroll runs this probe right before every sign, so hardware signs failed reproducibly on StrongBox devices.

Drive the probe operation to a terminal state immediately so its slot is freed: complete a dummy update()+sign() (non-interactive keys) or let the auth-required finish() fail (which still finalizes the op). Validity semantics are unchanged.