### PR TITLE
Fine-grained biometric error classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 ## [13.0.0]
 
 ### Added
-* **New `BiometricError.temporary`** for problems that resolve on their own with no user action (app backgrounded mid-prompt, a pruned keystore operation, a bad biometric read, a one-off system glitch). Consumers should treat it as "try again soon" and must not degrade to a weaker signer or force re-enrollment.
+* **Two new descriptive `BiometricError` causes**: `authenticationFailed` (an attempt that didn't succeed — unrecognised biometric or the platform couldn't process it; retrying usually works) and `notInteractive` (the prompt couldn't be shown, e.g. the app is backgrounded). Whether to retry or degrade is left to the consumer.
 
 ### Changed (breaking)
-* Errors that used to surface as `unknown` are now classified as `temporary` where we can reliably tell they're transient:
-  * **iOS**: `authenticationFailed`, `notInteractive`, app-cancel, and the observed `-1000` code; `-1018` now maps to `notAvailable` ("not available for this app"); keychain `errSecAuthFailed` maps to `temporary`, `errSecInteractionNotAllowed` to `notAvailable`.
-  * **Android**: pruned keystore operations, `TIMEOUT` (3), `UNABLE_TO_PROCESS` (2), and "key user not authenticated" now map to `temporary`.
-* Adding the enum value is breaking for exhaustive `switch`es on `BiometricError`.
+* Errors that used to surface as `unknown` are now classified more precisely:
+  * **iOS**: `authenticationFailed` and the observed `-1000` code → `authenticationFailed`; `notInteractive` → `notInteractive`; app-cancel → `systemCanceled`; `-1018` and keychain `errSecInteractionNotAllowed` → `notAvailable`; keychain `errSecAuthFailed` → `authenticationFailed`.
+  * **Android**: `UNABLE_TO_PROCESS` (2) and "key user not authenticated" → `authenticationFailed`. Pruned keystore ops and `TIMEOUT` (3) stay `unknown` with the enriched message; the retry-once for pruned ops still applies.
+* Adding enum values is breaking for exhaustive `switch`es on `BiometricError`.
+
 
 ## [12.1.0] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed (breaking)
 * Errors that used to surface as `unknown` are now classified as `temporary` where we can reliably tell they're transient:
-  * **iOS**: `authenticationFailed`, `notInteractive`, app-cancel, and the observed `-1000` code; `-1018` now maps to `notAvailable` ("not available for this app"); keychain `errSecAuthFailed` / `errSecInteractionNotAllowed` map to `temporary`.
+  * **iOS**: `authenticationFailed`, `notInteractive`, app-cancel, and the observed `-1000` code; `-1018` now maps to `notAvailable` ("not available for this app"); keychain `errSecAuthFailed` maps to `temporary`, `errSecInteractionNotAllowed` to `notAvailable`.
   * **Android**: pruned keystore operations, `TIMEOUT` (3), `UNABLE_TO_PROCESS` (2), and "key user not authenticated" now map to `temporary`.
 * Adding the enum value is breaking for exhaustive `switch`es on `BiometricError`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [13.0.0]
+
+### Added
+* **New `BiometricError.temporary`** for problems that resolve on their own with no user action (app backgrounded mid-prompt, a pruned keystore operation, a bad biometric read, a one-off system glitch). Consumers should treat it as "try again soon" and must not degrade to a weaker signer or force re-enrollment.
+
+### Changed (breaking)
+* Errors that used to surface as `unknown` are now classified as `temporary` where we can reliably tell they're transient:
+  * **iOS**: `authenticationFailed`, `notInteractive`, app-cancel, and the observed `-1000` code; `-1018` now maps to `notAvailable` ("not available for this app"); keychain `errSecAuthFailed` / `errSecInteractionNotAllowed` map to `temporary`.
+  * **Android**: pruned keystore operations, `TIMEOUT` (3), `UNABLE_TO_PROCESS` (2), and "key user not authenticated" now map to `temporary`.
+* Adding the enum value is breaking for exhaustive `switch`es on `BiometricError`.
+
 ## [12.1.0] - 2026-06-24
 
 ### Changed

--- a/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignatureApi.kt
+++ b/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignatureApi.kt
@@ -206,7 +206,14 @@ enum class BiometricError(val raw: Int) {
    * should migrate to [passcodeNotSet]. iOS/macOS mapping of
    * `kLAErrorPasscodeNotSet` changed in the same release.
    */
-  PASSCODE_NOT_SET(15);
+  PASSCODE_NOT_SET(15),
+  /**
+   * A transient problem that should resolve on its own — no user action
+   * needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
+   * a one-off system UI glitch). Callers should treat this as "try again
+   * soon" and must NOT degrade to a weaker signer or force re-enrollment.
+   */
+  TEMPORARY(16);
 
   companion object {
     fun ofRaw(raw: Int): BiometricError? {
@@ -603,10 +610,27 @@ data class CreateKeysConfig (
    */
   val failIfExists: Boolean? = null,
   /**
-   * [Android/iOS/macOS] Whether the key requires user authentication at use
-   * time (signing/decryption). Defaults to `true`. When `false`, the key can
-   * be used to sign/decrypt without any biometric or device-credential prompt.
-   * Ignored on Windows (Windows Hello always authenticates).
+   * [Android/iOS/macOS] Whether the key requires user authentication at *use*
+   * time (signing/decryption). Defaults to `true`.
+   *
+   * When `false`, the key is created without a user-authentication constraint
+   * and can be used to sign/decrypt **without any biometric or device-credential
+   * prompt**. This is useful for a non-interactive, device-bound key that lives
+   * alongside an interactive (biometric) key under a different [keyAlias].
+   *
+   * Platform behaviour:
+   * - **Android**: the keystore key is generated without
+   *   `setUserAuthenticationRequired(true)`, and signing/decryption skip the
+   *   `BiometricPrompt`.
+   * - **iOS/macOS**: the Secure Enclave key is created with only
+   *   `.privateKeyUsage` access control (no `.biometryAny`/`.userPresence`) and
+   *   `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, so signing never
+   *   prompts while the device is unlocked.
+   * - **Windows**: ignored — Windows Hello always authenticates.
+   *
+   * **Security note**: a non-interactive key provides device binding
+   * ("something you have") only; it does not verify user presence and cannot
+   * satisfy inherence-based SCA requirements.
    */
   val requireAuthentication: Boolean? = null
 )

--- a/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignatureApi.kt
+++ b/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignatureApi.kt
@@ -208,12 +208,16 @@ enum class BiometricError(val raw: Int) {
    */
   PASSCODE_NOT_SET(15),
   /**
-   * A transient problem that should resolve on its own — no user action
-   * needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
-   * a one-off system UI glitch). Callers should treat this as "try again
-   * soon" and must NOT degrade to a weaker signer or force re-enrollment.
+   * Authentication was attempted but did not succeed (e.g. an unrecognised
+   * biometric, or the platform could not process the sample). The key is
+   * intact — retrying usually works.
    */
-  TEMPORARY(16);
+  AUTHENTICATION_FAILED(16),
+  /**
+   * The prompt could not be shown because UI is not currently allowed
+   * (e.g. the app is backgrounded). Works again once the app is foreground.
+   */
+  NOT_INTERACTIVE(17);
 
   companion object {
     fun ofRaw(raw: Int): BiometricError? {

--- a/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignaturePlugin.kt
+++ b/android/src/main/kotlin/com/visionflutter/biometric_signature/BiometricSignaturePlugin.kt
@@ -451,7 +451,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
             )
             return
         }
-        if (payload.isBlank()) {
+        if (payloadBytes.isEmpty()) {
             callback(
                 Result.success(
                     SignatureResult(
@@ -486,7 +486,7 @@ class BiometricSignaturePlugin : FlutterPlugin, BiometricSignatureApi, ActivityA
                             signatureBytes = withContext(Dispatchers.IO) {
                                 val (signature, _) = cryptoOperations.prepareSignature(keyAlias, mode)
                                 try {
-                                    signature.update(payload.toByteArray(Charsets.UTF_8))
+                                    signature.update(payloadBytes)
                                     signature.sign()
                                 } catch (e: IllegalArgumentException) {
                                     throw IllegalArgumentException("Invalid payload", e)

--- a/android/src/main/kotlin/com/visionflutter/biometric_signature/ErrorMapper.kt
+++ b/android/src/main/kotlin/com/visionflutter/biometric_signature/ErrorMapper.kt
@@ -21,7 +21,8 @@ object ErrorMapper {
             BiometricError.PROMPT_ERROR -> "Biometric prompt error"
             BiometricError.KEY_ALREADY_EXISTS -> "Key already exists"
             BiometricError.PASSCODE_NOT_SET -> "No screen lock configured. Set up a PIN, pattern, or password to use biometrics"
-            BiometricError.TEMPORARY -> "Temporary problem, please try again"
+            BiometricError.AUTHENTICATION_FAILED -> "Authentication failed, please try again"
+            BiometricError.NOT_INTERACTIVE -> "Biometric prompt could not be shown right now"
             else -> {
                 // Preserve the raw BiometricPrompt error code and the original
                 // (localized) message so UNKNOWN failures stay self-classifying in
@@ -48,8 +49,7 @@ object ErrorMapper {
             msg.contains("BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED") -> BiometricError.SECURITY_UPDATE_REQUIRED
             msg.contains("BIOMETRIC_ERROR_UNSUPPORTED") -> BiometricError.NOT_SUPPORTED
 
-            causeCode == 2 -> BiometricError.TEMPORARY
-            causeCode == 3 -> BiometricError.TEMPORARY
+            causeCode == 2 -> BiometricError.AUTHENTICATION_FAILED
             causeCode == 4 -> BiometricError.SYSTEM_CANCELED
             causeCode == 5 -> BiometricError.USER_CANCELED
             causeCode == 7 -> BiometricError.LOCKED_OUT
@@ -65,10 +65,8 @@ object ErrorMapper {
 
             e is CancellationException -> BiometricError.USER_CANCELED
 
-            // Transient keystore faults: a pruned operation slot, or a key that
-            // wasn't authenticated in time. The key is intact — retry works.
-            isPrunedOperationError(e) -> BiometricError.TEMPORARY
-            msg.contains("Key user not authenticated") -> BiometricError.TEMPORARY
+            // The key required auth that wasn't satisfied — a failed attempt.
+            msg.contains("Key user not authenticated") -> BiometricError.AUTHENTICATION_FAILED
 
             e is IllegalArgumentException && (msg.contains("Base64") || msg.contains("payload")) -> BiometricError.INVALID_INPUT
 

--- a/android/src/main/kotlin/com/visionflutter/biometric_signature/ErrorMapper.kt
+++ b/android/src/main/kotlin/com/visionflutter/biometric_signature/ErrorMapper.kt
@@ -21,6 +21,7 @@ object ErrorMapper {
             BiometricError.PROMPT_ERROR -> "Biometric prompt error"
             BiometricError.KEY_ALREADY_EXISTS -> "Key already exists"
             BiometricError.PASSCODE_NOT_SET -> "No screen lock configured. Set up a PIN, pattern, or password to use biometrics"
+            BiometricError.TEMPORARY -> "Temporary problem, please try again"
             else -> {
                 // Preserve the raw BiometricPrompt error code and the original
                 // (localized) message so UNKNOWN failures stay self-classifying in
@@ -47,6 +48,8 @@ object ErrorMapper {
             msg.contains("BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED") -> BiometricError.SECURITY_UPDATE_REQUIRED
             msg.contains("BIOMETRIC_ERROR_UNSUPPORTED") -> BiometricError.NOT_SUPPORTED
 
+            causeCode == 2 -> BiometricError.TEMPORARY
+            causeCode == 3 -> BiometricError.TEMPORARY
             causeCode == 4 -> BiometricError.SYSTEM_CANCELED
             causeCode == 5 -> BiometricError.USER_CANCELED
             causeCode == 7 -> BiometricError.LOCKED_OUT
@@ -61,6 +64,11 @@ object ErrorMapper {
             e is KeyPermanentlyInvalidatedException -> BiometricError.KEY_INVALIDATED
 
             e is CancellationException -> BiometricError.USER_CANCELED
+
+            // Transient keystore faults: a pruned operation slot, or a key that
+            // wasn't authenticated in time. The key is intact — retry works.
+            isPrunedOperationError(e) -> BiometricError.TEMPORARY
+            msg.contains("Key user not authenticated") -> BiometricError.TEMPORARY
 
             e is IllegalArgumentException && (msg.contains("Base64") || msg.contains("payload")) -> BiometricError.INVALID_INPUT
 
@@ -104,14 +112,32 @@ object ErrorMapper {
         requestedStrength: BiometricStrength
     ): Pair<BiometricError, String> {
         return when (canAuthResult) {
-            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> Pair(BiometricError.NOT_AVAILABLE, "No biometric hardware available")
-            BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> Pair(BiometricError.NOT_AVAILABLE, "Biometric hardware unavailable")
+            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> Pair(
+                BiometricError.NOT_AVAILABLE,
+                "No biometric hardware available"
+            )
+
+            BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> Pair(
+                BiometricError.NOT_AVAILABLE,
+                "Biometric hardware unavailable"
+            )
+
             BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> {
-                val strengthName = if (requestedStrength == BiometricStrength.STRONG) "Class 3 (strong)" else "Class 2+ (weak or strong)"
+                val strengthName =
+                    if (requestedStrength == BiometricStrength.STRONG) "Class 3 (strong)" else "Class 2+ (weak or strong)"
                 Pair(BiometricError.NOT_ENROLLED, "No $strengthName biometrics enrolled.")
             }
-            BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED -> Pair(BiometricError.SECURITY_UPDATE_REQUIRED, "Security update required")
-            BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> Pair(BiometricError.NOT_SUPPORTED, "Biometric authentication not supported")
+
+            BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED -> Pair(
+                BiometricError.SECURITY_UPDATE_REQUIRED,
+                "Security update required"
+            )
+
+            BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> Pair(
+                BiometricError.NOT_SUPPORTED,
+                "Biometric authentication not supported"
+            )
+
             BiometricManager.BIOMETRIC_STATUS_UNKNOWN -> Pair(BiometricError.UNKNOWN, "Biometric status unknown")
             else -> Pair(BiometricError.UNKNOWN, "Unknown biometric error (code: $canAuthResult)")
         }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "12.1.0"
+    version: "13.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/biometric_signature/Sources/biometric_signature/BiometricSignatureApi.swift
+++ b/ios/biometric_signature/Sources/biometric_signature/BiometricSignatureApi.swift
@@ -229,6 +229,11 @@ enum BiometricError: Int {
   /// should migrate to [passcodeNotSet]. iOS/macOS mapping of
   /// `kLAErrorPasscodeNotSet` changed in the same release.
   case passcodeNotSet = 15
+  /// A transient problem that should resolve on its own — no user action
+  /// needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
+  /// a one-off system UI glitch). Callers should treat this as "try again
+  /// soon" and must NOT degrade to a weaker signer or force re-enrollment.
+  case temporary = 16
 }
 
 /// The cryptographic algorithm to use for key generation.
@@ -586,10 +591,27 @@ struct CreateKeysConfig: Hashable {
   ///
   /// When `false` (default), existing keys are silently replaced.
   var failIfExists: Bool? = nil
-  /// [Android/iOS/macOS] Whether the key requires user authentication at use
-  /// time (signing/decryption). Defaults to `true`. When `false`, the key can
-  /// be used to sign/decrypt without any biometric or device-credential prompt.
-  /// Ignored on Windows (Windows Hello always authenticates).
+  /// [Android/iOS/macOS] Whether the key requires user authentication at *use*
+  /// time (signing/decryption). Defaults to `true`.
+  ///
+  /// When `false`, the key is created without a user-authentication constraint
+  /// and can be used to sign/decrypt **without any biometric or device-credential
+  /// prompt**. This is useful for a non-interactive, device-bound key that lives
+  /// alongside an interactive (biometric) key under a different [keyAlias].
+  ///
+  /// Platform behaviour:
+  /// - **Android**: the keystore key is generated without
+  ///   `setUserAuthenticationRequired(true)`, and signing/decryption skip the
+  ///   `BiometricPrompt`.
+  /// - **iOS/macOS**: the Secure Enclave key is created with only
+  ///   `.privateKeyUsage` access control (no `.biometryAny`/`.userPresence`) and
+  ///   `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, so signing never
+  ///   prompts while the device is unlocked.
+  /// - **Windows**: ignored — Windows Hello always authenticates.
+  ///
+  /// **Security note**: a non-interactive key provides device binding
+  /// ("something you have") only; it does not verify user presence and cannot
+  /// satisfy inherence-based SCA requirements.
   var requireAuthentication: Bool? = nil
 
 

--- a/ios/biometric_signature/Sources/biometric_signature/BiometricSignatureApi.swift
+++ b/ios/biometric_signature/Sources/biometric_signature/BiometricSignatureApi.swift
@@ -229,11 +229,13 @@ enum BiometricError: Int {
   /// should migrate to [passcodeNotSet]. iOS/macOS mapping of
   /// `kLAErrorPasscodeNotSet` changed in the same release.
   case passcodeNotSet = 15
-  /// A transient problem that should resolve on its own — no user action
-  /// needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
-  /// a one-off system UI glitch). Callers should treat this as "try again
-  /// soon" and must NOT degrade to a weaker signer or force re-enrollment.
-  case temporary = 16
+  /// Authentication was attempted but did not succeed (e.g. an unrecognised
+  /// biometric, or the platform could not process the sample). The key is
+  /// intact — retrying usually works.
+  case authenticationFailed = 16
+  /// The prompt could not be shown because UI is not currently allowed
+  /// (e.g. the app is backgrounded). Works again once the app is foreground.
+  case notInteractive = 17
 }
 
 /// The cryptographic algorithm to use for key generation.

--- a/ios/biometric_signature/Sources/biometric_signature/BiometricSignaturePlugin.swift
+++ b/ios/biometric_signature/Sources/biometric_signature/BiometricSignaturePlugin.swift
@@ -778,13 +778,11 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin, BiometricSignatu
         case kLAErrorBiometryLockout:
             return .lockedOut
         case kLAErrorAuthenticationFailed:
-            // a bad read (wet finger, glance-away) — retrying can work.
-            return .temporary
+            return .authenticationFailed
         case kLAErrorAppCancel:
             return .systemCanceled
         case kLAErrorNotInteractive:
-            // no UI allowed (app backgrounded) — works again once foregrounded.
-            return .temporary
+            return .notInteractive
         case kLAErrorPasscodeNotSet:
             return .passcodeNotSet
         case kLAErrorInvalidContext:
@@ -795,7 +793,7 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin, BiometricSignatu
             // biometry not available *for this app* (permission/entitlement).
             return .notAvailable
         case -1000:
-            return .temporary
+            return .authenticationFailed
         default:
             return .unknown
         }
@@ -806,7 +804,7 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin, BiometricSignatu
         case errSecUserCanceled, -128:
             return .userCanceled
         case errSecAuthFailed:
-            return .temporary
+            return .authenticationFailed
         case errSecInteractionNotAllowed:
             // UI not allowed (locked/suppressed) — not reliably transient; let
             // callers fall back to a non-interactive key instead.

--- a/ios/biometric_signature/Sources/biometric_signature/BiometricSignaturePlugin.swift
+++ b/ios/biometric_signature/Sources/biometric_signature/BiometricSignaturePlugin.swift
@@ -808,8 +808,9 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin, BiometricSignatu
         case errSecAuthFailed:
             return .temporary
         case errSecInteractionNotAllowed:
-            // keychain interaction not allowed right now (locked/background).
-            return .temporary
+            // UI not allowed (locked/suppressed) — not reliably transient; let
+            // callers fall back to a non-interactive key instead.
+            return .notAvailable
         case -25300:
             return .keyNotFound
         default:

--- a/ios/biometric_signature/Sources/biometric_signature/BiometricSignaturePlugin.swift
+++ b/ios/biometric_signature/Sources/biometric_signature/BiometricSignaturePlugin.swift
@@ -778,11 +778,24 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin, BiometricSignatu
         case kLAErrorBiometryLockout:
             return .lockedOut
         case kLAErrorAuthenticationFailed:
-            return .unknown
+            // a bad read (wet finger, glance-away) — retrying can work.
+            return .temporary
+        case kLAErrorAppCancel:
+            return .systemCanceled
+        case kLAErrorNotInteractive:
+            // no UI allowed (app backgrounded) — works again once foregrounded.
+            return .temporary
         case kLAErrorPasscodeNotSet:
             return .passcodeNotSet
         case kLAErrorInvalidContext:
             return .promptError
+        // Newer iOS surfaces these under the LA domain without matching a
+        // public LAError constant; mapped from observed production events.
+        case -1018:
+            // biometry not available *for this app* (permission/entitlement).
+            return .notAvailable
+        case -1000:
+            return .temporary
         default:
             return .unknown
         }
@@ -793,9 +806,10 @@ public class BiometricSignaturePlugin: NSObject, FlutterPlugin, BiometricSignatu
         case errSecUserCanceled, -128:
             return .userCanceled
         case errSecAuthFailed:
-            return .unknown
+            return .temporary
         case errSecInteractionNotAllowed:
-            return .notAvailable
+            // keychain interaction not allowed right now (locked/background).
+            return .temporary
         case -25300:
             return .keyNotFound
         default:

--- a/lib/biometric_signature_platform_interface.pigeon.dart
+++ b/lib/biometric_signature_platform_interface.pigeon.dart
@@ -154,11 +154,14 @@ enum BiometricError {
   /// `kLAErrorPasscodeNotSet` changed in the same release.
   passcodeNotSet,
 
-  /// A transient problem that should resolve on its own — no user action
-  /// needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
-  /// a one-off system UI glitch). Callers should treat this as "try again
-  /// soon" and must NOT degrade to a weaker signer or force re-enrollment.
-  temporary,
+  /// Authentication was attempted but did not succeed (e.g. an unrecognised
+  /// biometric, or the platform could not process the sample). The key is
+  /// intact — retrying usually works.
+  authenticationFailed,
+
+  /// The prompt could not be shown because UI is not currently allowed
+  /// (e.g. the app is backgrounded). Works again once the app is foreground.
+  notInteractive,
 }
 
 /// The cryptographic algorithm to use for key generation.

--- a/lib/biometric_signature_platform_interface.pigeon.dart
+++ b/lib/biometric_signature_platform_interface.pigeon.dart
@@ -153,6 +153,12 @@ enum BiometricError {
   /// should migrate to [passcodeNotSet]. iOS/macOS mapping of
   /// `kLAErrorPasscodeNotSet` changed in the same release.
   passcodeNotSet,
+
+  /// A transient problem that should resolve on its own — no user action
+  /// needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
+  /// a one-off system UI glitch). Callers should treat this as "try again
+  /// soon" and must NOT degrade to a weaker signer or force re-enrollment.
+  temporary,
 }
 
 /// The cryptographic algorithm to use for key generation.
@@ -649,10 +655,27 @@ class CreateKeysConfig {
   /// When `false` (default), existing keys are silently replaced.
   bool? failIfExists;
 
-  /// [Android/iOS/macOS] Whether the key requires user authentication at use
-  /// time (signing/decryption). Defaults to `true`. When `false`, the key can
-  /// be used to sign/decrypt without any biometric or device-credential prompt.
-  /// Ignored on Windows (Windows Hello always authenticates).
+  /// [Android/iOS/macOS] Whether the key requires user authentication at *use*
+  /// time (signing/decryption). Defaults to `true`.
+  ///
+  /// When `false`, the key is created without a user-authentication constraint
+  /// and can be used to sign/decrypt **without any biometric or device-credential
+  /// prompt**. This is useful for a non-interactive, device-bound key that lives
+  /// alongside an interactive (biometric) key under a different [keyAlias].
+  ///
+  /// Platform behaviour:
+  /// - **Android**: the keystore key is generated without
+  ///   `setUserAuthenticationRequired(true)`, and signing/decryption skip the
+  ///   `BiometricPrompt`.
+  /// - **iOS/macOS**: the Secure Enclave key is created with only
+  ///   `.privateKeyUsage` access control (no `.biometryAny`/`.userPresence`) and
+  ///   `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, so signing never
+  ///   prompts while the device is unlocked.
+  /// - **Windows**: ignored — Windows Hello always authenticates.
+  ///
+  /// **Security note**: a non-interactive key provides device binding
+  /// ("something you have") only; it does not verify user presence and cannot
+  /// satisfy inherence-based SCA requirements.
   bool? requireAuthentication;
 
   List<Object?> _toList() {

--- a/pigeons/messages.dart
+++ b/pigeons/messages.dart
@@ -141,6 +141,12 @@ enum BiometricError {
   /// should migrate to [passcodeNotSet]. iOS/macOS mapping of
   /// `kLAErrorPasscodeNotSet` changed in the same release.
   passcodeNotSet,
+
+  /// A transient problem that should resolve on its own — no user action
+  /// needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
+  /// a one-off system UI glitch). Callers should treat this as "try again
+  /// soon" and must NOT degrade to a weaker signer or force re-enrollment.
+  temporary,
 }
 
 class BiometricAvailability {

--- a/pigeons/messages.dart
+++ b/pigeons/messages.dart
@@ -142,11 +142,14 @@ enum BiometricError {
   /// `kLAErrorPasscodeNotSet` changed in the same release.
   passcodeNotSet,
 
-  /// A transient problem that should resolve on its own — no user action
-  /// needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
-  /// a one-off system UI glitch). Callers should treat this as "try again
-  /// soon" and must NOT degrade to a weaker signer or force re-enrollment.
-  temporary,
+  /// Authentication was attempted but did not succeed (e.g. an unrecognised
+  /// biometric, or the platform could not process the sample). The key is
+  /// intact — retrying usually works.
+  authenticationFailed,
+
+  /// The prompt could not be shown because UI is not currently allowed
+  /// (e.g. the app is backgrounded). Works again once the app is foreground.
+  notInteractive,
 }
 
 class BiometricAvailability {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: biometric_signature
 description: Hardware-backed biometric authentication for Flutter (Android, iOS, macOS, Windows). Create cryptographic signatures using Secure Enclave, StrongBox, and Windows Hello.
 topics: [biometrics, secure-enclave, strongbox, rsa, ecdsa]
-version: 12.1.0
+version: 13.0.0
 homepage: https://github.com/chamodanethra/biometric_signature
 
 environment:

--- a/windows/messages.g.cpp
+++ b/windows/messages.g.cpp
@@ -846,7 +846,8 @@ CreateKeysConfig::CreateKeysConfig(
   const std::string* prompt_subtitle,
   const std::string* prompt_description,
   const std::string* cancel_button_text,
-  const bool* fail_if_exists)
+  const bool* fail_if_exists,
+  const bool* require_authentication)
  : signature_type_(signature_type ? std::optional<SignatureType>(*signature_type) : std::nullopt),
     enforce_biometric_(enforce_biometric ? std::optional<bool>(*enforce_biometric) : std::nullopt),
     set_invalidated_by_biometric_enrollment_(set_invalidated_by_biometric_enrollment ? std::optional<bool>(*set_invalidated_by_biometric_enrollment) : std::nullopt),
@@ -855,7 +856,8 @@ CreateKeysConfig::CreateKeysConfig(
     prompt_subtitle_(prompt_subtitle ? std::optional<std::string>(*prompt_subtitle) : std::nullopt),
     prompt_description_(prompt_description ? std::optional<std::string>(*prompt_description) : std::nullopt),
     cancel_button_text_(cancel_button_text ? std::optional<std::string>(*cancel_button_text) : std::nullopt),
-    fail_if_exists_(fail_if_exists ? std::optional<bool>(*fail_if_exists) : std::nullopt) {}
+    fail_if_exists_(fail_if_exists ? std::optional<bool>(*fail_if_exists) : std::nullopt),
+    require_authentication_(require_authentication ? std::optional<bool>(*require_authentication) : std::nullopt) {}
 
 const SignatureType* CreateKeysConfig::signature_type() const {
   return signature_type_ ? &(*signature_type_) : nullptr;
@@ -974,9 +976,22 @@ void CreateKeysConfig::set_fail_if_exists(bool value_arg) {
 }
 
 
+const bool* CreateKeysConfig::require_authentication() const {
+  return require_authentication_ ? &(*require_authentication_) : nullptr;
+}
+
+void CreateKeysConfig::set_require_authentication(const bool* value_arg) {
+  require_authentication_ = value_arg ? std::optional<bool>(*value_arg) : std::nullopt;
+}
+
+void CreateKeysConfig::set_require_authentication(bool value_arg) {
+  require_authentication_ = value_arg;
+}
+
+
 EncodableList CreateKeysConfig::ToEncodableList() const {
   EncodableList list;
-  list.reserve(9);
+  list.reserve(10);
   list.push_back(signature_type_ ? CustomEncodableValue(*signature_type_) : EncodableValue());
   list.push_back(enforce_biometric_ ? EncodableValue(*enforce_biometric_) : EncodableValue());
   list.push_back(set_invalidated_by_biometric_enrollment_ ? EncodableValue(*set_invalidated_by_biometric_enrollment_) : EncodableValue());
@@ -986,6 +1001,7 @@ EncodableList CreateKeysConfig::ToEncodableList() const {
   list.push_back(prompt_description_ ? EncodableValue(*prompt_description_) : EncodableValue());
   list.push_back(cancel_button_text_ ? EncodableValue(*cancel_button_text_) : EncodableValue());
   list.push_back(fail_if_exists_ ? EncodableValue(*fail_if_exists_) : EncodableValue());
+  list.push_back(require_authentication_ ? EncodableValue(*require_authentication_) : EncodableValue());
   return list;
 }
 
@@ -1026,6 +1042,10 @@ CreateKeysConfig CreateKeysConfig::FromEncodableList(const EncodableList& list) 
   auto& encodable_fail_if_exists = list[8];
   if (!encodable_fail_if_exists.IsNull()) {
     decoded.set_fail_if_exists(std::get<bool>(encodable_fail_if_exists));
+  }
+  auto& encodable_require_authentication = list[9];
+  if (!encodable_require_authentication.IsNull()) {
+    decoded.set_require_authentication(std::get<bool>(encodable_require_authentication));
   }
   return decoded;
 }

--- a/windows/messages.g.h
+++ b/windows/messages.g.h
@@ -156,7 +156,12 @@ enum class BiometricError {
   // were pattern-matching on [notAvailable] to drive a "no screen lock" UX
   // should migrate to [passcodeNotSet]. iOS/macOS mapping of
   // `kLAErrorPasscodeNotSet` changed in the same release.
-  kPasscodeNotSet = 15
+  kPasscodeNotSet = 15,
+  // A transient problem that should resolve on its own — no user action
+  // needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
+  // a one-off system UI glitch). Callers should treat this as "try again
+  // soon" and must NOT degrade to a weaker signer or force re-enrollment.
+  kTemporary = 16
 };
 
 // The cryptographic algorithm to use for key generation.
@@ -550,7 +555,8 @@ class CreateKeysConfig {
     const std::string* prompt_subtitle,
     const std::string* prompt_description,
     const std::string* cancel_button_text,
-    const bool* fail_if_exists);
+    const bool* fail_if_exists,
+    const bool* require_authentication);
 
   // [Android/iOS/macOS] The cryptographic algorithm to use.
   // Windows only supports RSA and ignores this field.
@@ -610,6 +616,31 @@ class CreateKeysConfig {
   void set_fail_if_exists(const bool* value_arg);
   void set_fail_if_exists(bool value_arg);
 
+  // [Android/iOS/macOS] Whether the key requires user authentication at *use*
+  // time (signing/decryption). Defaults to `true`.
+  //
+  // When `false`, the key is created without a user-authentication constraint
+  // and can be used to sign/decrypt **without any biometric or device-credential
+  // prompt**. This is useful for a non-interactive, device-bound key that lives
+  // alongside an interactive (biometric) key under a different [keyAlias].
+  //
+  // Platform behaviour:
+  // - **Android**: the keystore key is generated without
+  //   `setUserAuthenticationRequired(true)`, and signing/decryption skip the
+  //   `BiometricPrompt`.
+  // - **iOS/macOS**: the Secure Enclave key is created with only
+  //   `.privateKeyUsage` access control (no `.biometryAny`/`.userPresence`) and
+  //   `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, so signing never
+  //   prompts while the device is unlocked.
+  // - **Windows**: ignored — Windows Hello always authenticates.
+  //
+  // **Security note**: a non-interactive key provides device binding
+  // ("something you have") only; it does not verify user presence and cannot
+  // satisfy inherence-based SCA requirements.
+  const bool* require_authentication() const;
+  void set_require_authentication(const bool* value_arg);
+  void set_require_authentication(bool value_arg);
+
  private:
   static CreateKeysConfig FromEncodableList(const flutter::EncodableList& list);
   flutter::EncodableList ToEncodableList() const;
@@ -624,6 +655,7 @@ class CreateKeysConfig {
   std::optional<std::string> prompt_description_;
   std::optional<std::string> cancel_button_text_;
   std::optional<bool> fail_if_exists_;
+  std::optional<bool> require_authentication_;
 };
 
 

--- a/windows/messages.g.h
+++ b/windows/messages.g.h
@@ -157,11 +157,13 @@ enum class BiometricError {
   // should migrate to [passcodeNotSet]. iOS/macOS mapping of
   // `kLAErrorPasscodeNotSet` changed in the same release.
   kPasscodeNotSet = 15,
-  // A transient problem that should resolve on its own — no user action
-  // needed (e.g. app backgrounded mid-prompt, a pruned keystore operation,
-  // a one-off system UI glitch). Callers should treat this as "try again
-  // soon" and must NOT degrade to a weaker signer or force re-enrollment.
-  kTemporary = 16
+  // Authentication was attempted but did not succeed (e.g. an unrecognised
+  // biometric, or the platform could not process the sample). The key is
+  // intact — retrying usually works.
+  kAuthenticationFailed = 16,
+  // The prompt could not be shown because UI is not currently allowed
+  // (e.g. the app is backgrounded). Works again once the app is foreground.
+  kNotInteractive = 17
 };
 
 // The cryptographic algorithm to use for key generation.


### PR DESCRIPTION
tightens error classification
- new err types (breaking): `.authenticationFailed` & `.notInteractive`
   - bump 13.0.0 (breaking: new enum value)
- more specific mapping of underlying platform errors, even reflects some undocumented errors I came across during usage
